### PR TITLE
Fixed No Damage When Wearing Leather Armour

### DIFF
--- a/src/main/java/dk/tij/freezingEffect/constants/TemperatureConstants.java
+++ b/src/main/java/dk/tij/freezingEffect/constants/TemperatureConstants.java
@@ -10,6 +10,7 @@ import java.util.function.Function;
 
 public final class TemperatureConstants {
     public static final int
+            VANILLA_DAMAGE_FREEZE_TICKS = 40,
             VANILLA_MIN_FREEZE_TICKS = 0,
             VANILLA_MAX_FREEZE_TICKS = 140;
 

--- a/src/main/java/dk/tij/freezingEffect/handler/TemperatureHandler.java
+++ b/src/main/java/dk/tij/freezingEffect/handler/TemperatureHandler.java
@@ -2,11 +2,11 @@ package dk.tij.freezingEffect.handler;
 
 import dk.tij.freezingEffect.constants.InterpolationFunctions;
 import dk.tij.freezingEffect.constants.TemperatureConstants;
+import dk.tij.freezingEffect.utils.ItemUtils;
 import dk.tij.freezingEffect.utils.TemperatureUtils;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.block.Block;
+import org.bukkit.damage.DamageSource;
+import org.bukkit.damage.DamageType;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -20,12 +20,15 @@ public class TemperatureHandler {
     private final FreezeHandler freezeHandler;
 
     private final Map<UUID, Double> actualPlayerFreezeTicks = new HashMap<>();
+    private final DamageSource freezingDamageSource;
 
     private BukkitRunnable decayTask;
+    private BukkitRunnable leatherArmourDamageTask;
 
     public TemperatureHandler(JavaPlugin plugin, FreezeHandler freezeHandler) {
         this.plugin = plugin;
         this.freezeHandler = freezeHandler;
+        this.freezingDamageSource = DamageSource.builder(DamageType.FREEZE).build();
     }
 
     public void startDecayTask() {
@@ -33,19 +36,30 @@ public class TemperatureHandler {
             decayTask = new BukkitRunnable() {
                 @Override
                 public void run() {
+                    Bukkit.getOnlinePlayers().forEach(player -> tickPlayerTemperature(player));
                     for (Player player : Bukkit.getOnlinePlayers()) {
                         tickPlayerTemperature(player);
                     }
                 }
             };
         }
+        if (leatherArmourDamageTask == null) {
+            leatherArmourDamageTask = new BukkitRunnable() {
+                @Override
+                public void run() {
+                    Bukkit.getOnlinePlayers().forEach(player -> applyDamageIfLeatherArmour(player));
+                }
+            };
+        }
         decayTask.runTaskTimer(plugin, 0L, 1L);
+        leatherArmourDamageTask.runTaskTimer(plugin, 1L, TemperatureConstants.VANILLA_DAMAGE_FREEZE_TICKS);
     }
 
     public void stopDecayTask() {
-        if (decayTask == null)
-            return;
+        if (decayTask == null) return;
+        if (leatherArmourDamageTask == null) return;
         decayTask.cancel();
+        leatherArmourDamageTask.cancel();
     }
 
     public void reloadDecayTask() {
@@ -73,6 +87,13 @@ public class TemperatureHandler {
 
         player.sendMessage(String.format("FreezeTicks %3d | FractionalTarget: %3.1f | FreezePoints: %4.2f",
                 freezeTicks, fractionalChange, nextActualFreezeTick));
+    }
+
+    private void applyDamageIfLeatherArmour(Player player) {
+        if (!ItemUtils.isWearingLeatherArmour(player)) return;
+        if (player.getFreezeTicks() <= TemperatureConstants.VANILLA_MAX_FREEZE_TICKS * 1.1) return;
+
+        player.damage(1d, freezingDamageSource);
     }
 
     private int computeTarget(Player player) {

--- a/src/main/java/dk/tij/freezingEffect/utils/ItemUtils.java
+++ b/src/main/java/dk/tij/freezingEffect/utils/ItemUtils.java
@@ -1,7 +1,9 @@
 package dk.tij.freezingEffect.utils;
 
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
 
 public final class ItemUtils {
     public static boolean isArmourItem(Material material) {
@@ -11,5 +13,12 @@ public final class ItemUtils {
             case EquipmentSlot.HEAD, EquipmentSlot.CHEST, EquipmentSlot.LEGS, EquipmentSlot.FEET -> true;
             default -> false;
         };
+    }
+
+    public static boolean isWearingLeatherArmour(Player player) {
+        for (ItemStack item : player.getInventory().getArmorContents()) {
+            if (item != null && item.getType().toString().contains("LEATHER")) return true;
+        }
+        return false;
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: FreezingEffect
-version: '0.3.1_dev'
+version: '0.3.2_dev'
 main: dk.tij.freezingEffect.FreezingEffect
 api-version: '1.21'


### PR DESCRIPTION
Bypassing the vanilla mechanic, that a player does not receive any damage when having FreezeTicks >= 140 and wearing leather armour, by applying damage manually every two seconds (vanilla duration) when wearing leather armour.