### PR TITLE
Fixed Freezing In Powder Snow

### DIFF
--- a/src/main/java/dk/tij/freezingEffect/constants/TemperatureConstants.java
+++ b/src/main/java/dk/tij/freezingEffect/constants/TemperatureConstants.java
@@ -14,7 +14,7 @@ public final class TemperatureConstants {
             VANILLA_MIN_FREEZE_TICKS = 0,
             VANILLA_MAX_FREEZE_TICKS = 140;
 
-    public static final double BASE_POWDER_SNOW_FACTOR = 1.30;
+    public static final double BASE_POWDER_SNOW_FACTOR = 1.225; // approximate sqrt of 1.5
 
     public static final Map<String, Function<Double, Double>> INTERPOLATION_FUNCTIONS_MAPPING = Map.of(
             "linear", InterpolationFunctions::linear,

--- a/src/main/java/dk/tij/freezingEffect/constants/TemperatureConstants.java
+++ b/src/main/java/dk/tij/freezingEffect/constants/TemperatureConstants.java
@@ -14,6 +14,8 @@ public final class TemperatureConstants {
             VANILLA_MIN_FREEZE_TICKS = 0,
             VANILLA_MAX_FREEZE_TICKS = 140;
 
+    public static final double BASE_POWDER_SNOW_FACTOR = 1.30;
+
     public static final Map<String, Function<Double, Double>> INTERPOLATION_FUNCTIONS_MAPPING = Map.of(
             "linear", InterpolationFunctions::linear,
             "smoothstep", InterpolationFunctions::smoothstep,
@@ -28,7 +30,7 @@ public final class TemperatureConstants {
             HEAT_RADIUS_SQUARED = HEAT_RADIUS * HEAT_RADIUS,
             MAX_POSSIBLE_ISOLATION = 0.80,
             PLAYER_BURNING_BOOST = 1.10,
-            PLAYER_POWDER_SNOW_BOOST = 2.00;
+            PLAYER_POWDER_SNOW_BOOST = 1.00;
 
     public static final Map<Material, Double> ARMOUR_PIECE_ISOLATION = new HashMap<>();
     public static final Map<Material, HeatSource> HEAT_SOURCE_WARMING = new HashMap<>();

--- a/src/main/java/dk/tij/freezingEffect/constants/TemperatureConstants.java
+++ b/src/main/java/dk/tij/freezingEffect/constants/TemperatureConstants.java
@@ -27,7 +27,8 @@ public final class TemperatureConstants {
             HEAT_RADIUS = 5,
             HEAT_RADIUS_SQUARED = HEAT_RADIUS * HEAT_RADIUS,
             MAX_POSSIBLE_ISOLATION = 0.80,
-            PLAYER_BURNING_BOOST = 1.10;
+            PLAYER_BURNING_BOOST = 1.10,
+            PLAYER_POWDER_SNOW_BOOST = 2.00;
 
     public static final Map<Material, Double> ARMOUR_PIECE_ISOLATION = new HashMap<>();
     public static final Map<Material, HeatSource> HEAT_SOURCE_WARMING = new HashMap<>();

--- a/src/main/java/dk/tij/freezingEffect/handler/ResourceHandler.java
+++ b/src/main/java/dk/tij/freezingEffect/handler/ResourceHandler.java
@@ -77,6 +77,10 @@ public class ResourceHandler {
         TemperatureConstants.PLAYER_BURNING_BOOST = Maths.clampI0To100(
                 config.getInt("frost.playerBurningBoost", 0)
         ) * TO_PERCENT_CONVERSION_FACTOR + 1d;
+
+        TemperatureConstants.PLAYER_POWDER_SNOW_BOOST = Maths.clampPositiveI(
+                config.getInt("frost.playerPowderSnowBoost", 0)
+        ) * TO_PERCENT_CONVERSION_FACTOR + 1d;
     }
 
     private void loadInterpolationFunction() {

--- a/src/main/java/dk/tij/freezingEffect/handler/TemperatureHandler.java
+++ b/src/main/java/dk/tij/freezingEffect/handler/TemperatureHandler.java
@@ -86,10 +86,12 @@ public class TemperatureHandler {
         }
 
         if (TemperatureUtils.isPlayerInPowderSnow(player) && TemperatureConstants.PLAYER_POWDER_SNOW_BOOST >= 0) {
+            double powderSnowValue = TemperatureConstants.BASE_POWDER_SNOW_FACTOR;
+            powderSnowValue *= TemperatureConstants.PLAYER_POWDER_SNOW_BOOST;
             if (fractionalChange < 0)
-                fractionalChange = TemperatureConstants.PLAYER_POWDER_SNOW_BOOST;
+                fractionalChange = powderSnowValue;
             else
-                fractionalChange *= TemperatureConstants.PLAYER_POWDER_SNOW_BOOST;
+                fractionalChange += powderSnowValue;
         }
 
         UUID playerUUID = player.getUniqueId();

--- a/src/main/java/dk/tij/freezingEffect/handler/TemperatureHandler.java
+++ b/src/main/java/dk/tij/freezingEffect/handler/TemperatureHandler.java
@@ -85,7 +85,7 @@ public class TemperatureHandler {
                 fractionalChange = fireValue;
         }
 
-        if (TemperatureUtils.isPlayerInPowderSnow(player)) {
+        if (TemperatureUtils.isPlayerInPowderSnow(player) && TemperatureConstants.PLAYER_POWDER_SNOW_BOOST >= 0) {
             if (fractionalChange < 0)
                 fractionalChange = TemperatureConstants.PLAYER_POWDER_SNOW_BOOST;
             else

--- a/src/main/java/dk/tij/freezingEffect/handler/TemperatureHandler.java
+++ b/src/main/java/dk/tij/freezingEffect/handler/TemperatureHandler.java
@@ -85,8 +85,10 @@ public class TemperatureHandler {
                 fractionalChange = fireValue;
         }
 
-        if (TemperatureUtils.isPlayerInPowderSnow(player) && TemperatureConstants.PLAYER_POWDER_SNOW_BOOST >= 0) {
-            double powderSnowValue = TemperatureConstants.BASE_POWDER_SNOW_FACTOR;
+        int blocksOfPowderSnow = TemperatureUtils.getAmountOfPowderSnowBlocksInPlayer(player);
+        if (blocksOfPowderSnow > 0) {
+            double powderSnowValue = 1d;
+            powderSnowValue *= Math.pow(TemperatureConstants.BASE_POWDER_SNOW_FACTOR, blocksOfPowderSnow);
             powderSnowValue *= TemperatureConstants.PLAYER_POWDER_SNOW_BOOST;
             if (fractionalChange < 0)
                 fractionalChange = powderSnowValue;

--- a/src/main/java/dk/tij/freezingEffect/handler/TemperatureHandler.java
+++ b/src/main/java/dk/tij/freezingEffect/handler/TemperatureHandler.java
@@ -85,6 +85,13 @@ public class TemperatureHandler {
                 fractionalChange = fireValue;
         }
 
+        if (TemperatureUtils.isPlayerInPowderSnow(player)) {
+            if (fractionalChange < 0)
+                fractionalChange = TemperatureConstants.PLAYER_POWDER_SNOW_BOOST;
+            else
+                fractionalChange *= TemperatureConstants.PLAYER_POWDER_SNOW_BOOST;
+        }
+
         UUID playerUUID = player.getUniqueId();
 
         double previousActualFreezeTicks = actualPlayerFreezeTicks.get(playerUUID);

--- a/src/main/java/dk/tij/freezingEffect/utils/TemperatureUtils.java
+++ b/src/main/java/dk/tij/freezingEffect/utils/TemperatureUtils.java
@@ -69,9 +69,11 @@ public final class TemperatureUtils {
         return player.getFireTicks() > 0;
     }
 
-    public static boolean isPlayerInPowderSnow(Player player) {
-        return player.getEyeLocation().getBlock().getType() == Material.POWDER_SNOW
-                || player.getLocation().getBlock().getType() == Material.POWDER_SNOW;
+    public static int getAmountOfPowderSnowBlocksInPlayer(Player player) {
+        int result = 0;
+        result += (Material.POWDER_SNOW.equals(player.getEyeLocation().getBlock().getType())) ? 1 : 0;
+        result += (Material.POWDER_SNOW.equals(player.getLocation().getBlock().getType())) ? 1 : 0;
+        return result;
     }
 
     private static boolean isHeatSourceUnobstructed(Location playerLocation, Location heatSourceLocation) {

--- a/src/main/java/dk/tij/freezingEffect/utils/TemperatureUtils.java
+++ b/src/main/java/dk/tij/freezingEffect/utils/TemperatureUtils.java
@@ -69,6 +69,11 @@ public final class TemperatureUtils {
         return player.getFireTicks() > 0;
     }
 
+    public static boolean isPlayerInPowderSnow(Player player) {
+        return player.getEyeLocation().getBlock().getType() == Material.POWDER_SNOW
+                || player.getLocation().getBlock().getType() == Material.POWDER_SNOW;
+    }
+
     private static boolean isHeatSourceUnobstructed(Location playerLocation, Location heatSourceLocation) {
         Vector direction = heatSourceLocation.toVector().subtract(playerLocation.toVector());
         double distance = direction.length();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,7 +13,7 @@ frost:
       LEATHER_HELMET: 15
 
   playerBurningBoost: 10
-  playerPowderSnowBoost: 100
+  playerPowderSnowBoost: 0
 
   heatSources:
     TORCH:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,7 +13,7 @@ frost:
       LEATHER_HELMET: 15
 
   playerBurningBoost: 10
-  playerPowderSnowBoost: 30
+  playerPowderSnowBoost: 100
 
   heatSources:
     TORCH:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,6 +13,7 @@ frost:
       LEATHER_HELMET: 15
 
   playerBurningBoost: 10
+  playerPowderSnowBoost: 30
 
   heatSources:
     TORCH:


### PR DESCRIPTION
Players can now freeze again in powder snow. Even faster when in two blocks.
Base rate is 22.5% in one block, 50% in two blocks.
After the base rate is applied, the configurable boost rate is applied.

Closes #14 