### PR TITLE
Admin Commands, Debug & Permissions

### DIFF
--- a/src/main/java/dk/tij/freezingEffect/FreezingEffect.java
+++ b/src/main/java/dk/tij/freezingEffect/FreezingEffect.java
@@ -35,7 +35,7 @@ public final class FreezingEffect extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new PlayerRespawnListener(temperatureHandler, freezeHandler), this);
 
         getCommand(CommandLabels.COMMAND_LABEL).setExecutor(new WinterCommand(this));
-        getCommand(CommandLabels.COMMAND_LABEL).setTabCompleter(new WinterTabCompleter());
+        getCommand(CommandLabels.COMMAND_LABEL).setTabCompleter(new WinterTabCompleter(this));
 
         freezeHandler.start();
         temperatureHandler.startDecayTask();

--- a/src/main/java/dk/tij/freezingEffect/FreezingEffect.java
+++ b/src/main/java/dk/tij/freezingEffect/FreezingEffect.java
@@ -1,5 +1,8 @@
 package dk.tij.freezingEffect;
 
+import dk.tij.freezingEffect.commands.CommandLabels;
+import dk.tij.freezingEffect.commands.WinterCommand;
+import dk.tij.freezingEffect.commands.utils.WinterTabCompleter;
 import dk.tij.freezingEffect.events.PlayerQuitListener;
 import dk.tij.freezingEffect.events.PlayerRespawnListener;
 import dk.tij.freezingEffect.events.PlayerJoinListener;
@@ -8,8 +11,6 @@ import dk.tij.freezingEffect.handler.PlayerDataHandler;
 import dk.tij.freezingEffect.handler.ResourceHandler;
 import dk.tij.freezingEffect.handler.TemperatureHandler;
 import org.bukkit.plugin.java.JavaPlugin;
-
-import java.io.File;
 
 public final class FreezingEffect extends JavaPlugin {
     private ResourceHandler resourceHandler;
@@ -20,28 +21,32 @@ public final class FreezingEffect extends JavaPlugin {
     @Override
     public void onEnable() {
         // Plugin startup logic
-        getComponentLogger().info("Plugin successfully loaded!");
         saveDefaultConfig();
+        getComponentLogger().info("Plugin successfully loaded!");
 
         resourceHandler = new ResourceHandler(this);
         playerDataHandler = new PlayerDataHandler(this);
 
         freezeHandler = new FreezeHandler(this);
-        freezeHandler.start();
 
         temperatureHandler = new TemperatureHandler(this, freezeHandler);
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(playerDataHandler, temperatureHandler), this);
         getServer().getPluginManager().registerEvents(new PlayerQuitListener(playerDataHandler, temperatureHandler), this);
         getServer().getPluginManager().registerEvents(new PlayerRespawnListener(temperatureHandler, freezeHandler), this);
 
+        getCommand(CommandLabels.COMMAND_LABEL).setExecutor(new WinterCommand(this));
+        getCommand(CommandLabels.COMMAND_LABEL).setTabCompleter(new WinterTabCompleter());
+
+        freezeHandler.start();
         temperatureHandler.startDecayTask();
     }
 
     @Override
     public void reloadConfig() {
         super.reloadConfig();
-        if (resourceHandler == null || temperatureHandler == null) return;
-        resourceHandler.loadConfig();
+        if (resourceHandler == null) return;
+        resourceHandler.reloadConfig();
+        if (temperatureHandler == null) return;
         temperatureHandler.reloadDecayTask();
     }
 
@@ -54,9 +59,15 @@ public final class FreezingEffect extends JavaPlugin {
         temperatureHandler.stopDecayTask();
 
         playerDataHandler.saveConfig();
+    }
 
-        // TODO: REMOVE FROM PRODUCTION
-        /*File configFile = new File(getDataFolder(), "config.yml");
-        if (configFile.exists()) configFile.delete();*/
+    public void setDebug(boolean debug) {
+        if (resourceHandler == null) return;
+        resourceHandler.setDebug(debug);
+    }
+
+    public boolean isDebug() {
+        if (resourceHandler == null) return false;
+        return resourceHandler.isDebug();
     }
 }

--- a/src/main/java/dk/tij/freezingEffect/commands/CommandLabels.java
+++ b/src/main/java/dk/tij/freezingEffect/commands/CommandLabels.java
@@ -5,7 +5,10 @@ public final class CommandLabels {
 
     public static final String ARGUMENT_RELOAD = "reload";
     public static final String ARGUMENT_DEBUG = "debug";
+    public static final String ARGUMENT_CONFIG = "config";
 
     public static final String DEBUG_ARGUMENT_ON = "on";
     public static final String DEBUG_ARGUMENT_OFF = "off";
+    public static final String CONFIG_ARGUMENT_GET = "get";
+    public static final String CONFIG_ARGUMENT_SET = "set";
 }

--- a/src/main/java/dk/tij/freezingEffect/commands/CommandLabels.java
+++ b/src/main/java/dk/tij/freezingEffect/commands/CommandLabels.java
@@ -1,0 +1,11 @@
+package dk.tij.freezingEffect.commands;
+
+public final class CommandLabels {
+    public static final String COMMAND_LABEL = "winter";
+
+    public static final String ARGUMENT_RELOAD = "reload";
+    public static final String ARGUMENT_DEBUG = "debug";
+
+    public static final String DEBUG_ARGUMENT_ON = "on";
+    public static final String DEBUG_ARGUMENT_OFF = "off";
+}

--- a/src/main/java/dk/tij/freezingEffect/commands/CommandPermissions.java
+++ b/src/main/java/dk/tij/freezingEffect/commands/CommandPermissions.java
@@ -1,0 +1,6 @@
+package dk.tij.freezingEffect.commands;
+
+public final class CommandPermissions {
+    private static final String COMMAND_PREFIX = "freezingeffect";
+    public static final String BASIC_COMMAND = COMMAND_PREFIX + "command";
+}

--- a/src/main/java/dk/tij/freezingEffect/commands/WinterCommand.java
+++ b/src/main/java/dk/tij/freezingEffect/commands/WinterCommand.java
@@ -1,0 +1,50 @@
+package dk.tij.freezingEffect.commands;
+
+import dk.tij.freezingEffect.FreezingEffect;
+import dk.tij.freezingEffect.commands.utils.ChatMessages;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
+public class WinterCommand implements CommandExecutor {
+    private final FreezingEffect plugin;
+
+    public WinterCommand(FreezingEffect plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] arguments) {
+        if (!commandSender.hasPermission(CommandPermissions.BASIC_COMMAND)) {
+            commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.RED + "You do not have permission to use this command.");
+            return true;
+        }
+
+        if (arguments.length == 1 && arguments[0].equalsIgnoreCase(CommandLabels.ARGUMENT_RELOAD)) {
+            plugin.reloadConfig();
+            commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.GREEN + "Configuration reloaded.");
+            return true;
+        }
+
+        if (arguments.length == 2 && arguments[0].equalsIgnoreCase(CommandLabels.ARGUMENT_DEBUG)) {
+            boolean turnOn = arguments[1].equalsIgnoreCase(CommandLabels.DEBUG_ARGUMENT_ON);
+            boolean turnOff = arguments[1].equalsIgnoreCase(CommandLabels.DEBUG_ARGUMENT_OFF);
+
+            if (!turnOn && !turnOff) {
+                commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.AQUA + "Usage: /winter debug <on/off>");
+                return true;
+            }
+
+            plugin.setDebug(turnOn);
+
+            commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.GREEN + "Debug: " + (turnOn ? "ON" : "OFF"));
+
+            return true;
+        }
+
+        commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.AQUA + "Usage: /winter <reload/debug>");
+        return true;
+    }
+}

--- a/src/main/java/dk/tij/freezingEffect/commands/WinterCommand.java
+++ b/src/main/java/dk/tij/freezingEffect/commands/WinterCommand.java
@@ -28,23 +28,87 @@ public class WinterCommand implements CommandExecutor {
             return true;
         }
 
-        if (arguments.length == 2 && arguments[0].equalsIgnoreCase(CommandLabels.ARGUMENT_DEBUG)) {
-            boolean turnOn = arguments[1].equalsIgnoreCase(CommandLabels.DEBUG_ARGUMENT_ON);
-            boolean turnOff = arguments[1].equalsIgnoreCase(CommandLabels.DEBUG_ARGUMENT_OFF);
+        if (arguments.length == 2) {
+            if (arguments[0].equalsIgnoreCase(CommandLabels.ARGUMENT_DEBUG)) {
+                boolean turnOn = arguments[1].equalsIgnoreCase(CommandLabels.DEBUG_ARGUMENT_ON);
+                boolean turnOff = arguments[1].equalsIgnoreCase(CommandLabels.DEBUG_ARGUMENT_OFF);
 
-            if (!turnOn && !turnOff) {
-                commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.AQUA + "Usage: /winter debug <on/off>");
+                if (!turnOn && !turnOff) {
+                    commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.AQUA + "Usage: /winter debug <on/off>");
+                    return true;
+                }
+
+                plugin.setDebug(turnOn);
+
+                commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.GREEN + "Debug: " + (turnOn ? "ON" : "OFF"));
+
+                return true;
+            }
+        }
+
+        if (arguments.length >= 2 && arguments[0].equalsIgnoreCase(CommandLabels.ARGUMENT_CONFIG)) {
+            if (arguments[1].equalsIgnoreCase(CommandLabels.CONFIG_ARGUMENT_GET)) {
+                if (arguments.length != 3) {
+                    commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.AQUA + "Usage: /winter config get <path>");
+                    return true;
+                }
+
+                String path = arguments[2];
+                Object value = plugin.getConfig().get(path);
+
+                if (value == null) {
+                    commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.RED + "Path not found.");
+                } else {
+                    commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.GREEN + path + " = " + value);
+                }
                 return true;
             }
 
-            plugin.setDebug(turnOn);
+            if (arguments[1].equalsIgnoreCase(CommandLabels.CONFIG_ARGUMENT_SET)) {
+                if (arguments.length != 4) {
+                    commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.AQUA + "Usage: /winter config set <path> <value>");
+                    return true;
+                }
 
-            commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.GREEN + "Debug: " + (turnOn ? "ON" : "OFF"));
+                String path = arguments[2];
+                String rawValue = arguments[3];
 
-            return true;
+                if (plugin.getConfig().get(path) == null) {
+                    commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.RED + "Path not found.");
+                    return true;
+                }
+
+                Object parsed = parseConfigValue(rawValue);
+                if (parsed == null) {
+                    commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.AQUA + "Failed to parse configuration value.");
+                    return true;
+                }
+
+                plugin.getConfig().set(path, parsed);
+                plugin.saveConfig();
+                plugin.reloadConfig();
+
+                commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.GREEN + "Updated configuration.");
+                return true;
+            }
         }
 
         commandSender.sendMessage(ChatMessages.CHAT_PREFIX + ChatColor.AQUA + "Usage: /winter <reload/debug>");
         return true;
+    }
+
+    private Object parseConfigValue(String rawValue) {
+        if (rawValue.equalsIgnoreCase("true")) return Boolean.TRUE;
+        if (rawValue.equalsIgnoreCase("false")) return Boolean.FALSE;
+
+        try {
+            return Integer.parseInt(rawValue);
+        } catch (NumberFormatException ignored) {}
+
+        try {
+            return Double.parseDouble(rawValue);
+        } catch (NumberFormatException ignored) {}
+
+        return rawValue;
     }
 }

--- a/src/main/java/dk/tij/freezingEffect/commands/utils/AdminDebug.java
+++ b/src/main/java/dk/tij/freezingEffect/commands/utils/AdminDebug.java
@@ -1,0 +1,13 @@
+package dk.tij.freezingEffect.commands.utils;
+
+import dk.tij.freezingEffect.commands.CommandPermissions;
+import org.bukkit.entity.Player;
+
+public final class AdminDebug {
+    public static void printFreezeTicks(Player player, int freezeTicks, double fractionalChange, double nextActualFreezeTick) {
+        if (!player.hasPermission(CommandPermissions.BASIC_COMMAND)) return;
+
+        player.sendMessage(String.format("FreezeTicks %3d | FractionalTarget: %3.1f | FreezePoints: %4.2f",
+                freezeTicks, fractionalChange, nextActualFreezeTick));
+    }
+}

--- a/src/main/java/dk/tij/freezingEffect/commands/utils/ChatMessages.java
+++ b/src/main/java/dk/tij/freezingEffect/commands/utils/ChatMessages.java
@@ -1,0 +1,7 @@
+package dk.tij.freezingEffect.commands.utils;
+
+import org.bukkit.ChatColor;
+
+public final class ChatMessages {
+    public static final String CHAT_PREFIX = "[" + ChatColor.AQUA + "" + ChatColor.BOLD + "FreezingEffect" + ChatColor.WHITE + "] ";
+}

--- a/src/main/java/dk/tij/freezingEffect/commands/utils/WinterTabCompleter.java
+++ b/src/main/java/dk/tij/freezingEffect/commands/utils/WinterTabCompleter.java
@@ -1,0 +1,25 @@
+package dk.tij.freezingEffect.commands.utils;
+
+import dk.tij.freezingEffect.commands.CommandLabels;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class WinterTabCompleter implements TabCompleter {
+    @Override
+    public List<String> onTabComplete(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] arguments) {
+        if (arguments.length == 1) {
+            return List.of(CommandLabels.ARGUMENT_RELOAD, CommandLabels.ARGUMENT_DEBUG);
+        }
+
+        if (arguments.length == 2 && arguments[0].equals(CommandLabels.ARGUMENT_DEBUG)) {
+            return List.of(CommandLabels.DEBUG_ARGUMENT_ON, CommandLabels.DEBUG_ARGUMENT_OFF);
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/dk/tij/freezingEffect/commands/utils/WinterTabCompleter.java
+++ b/src/main/java/dk/tij/freezingEffect/commands/utils/WinterTabCompleter.java
@@ -1,25 +1,76 @@
 package dk.tij.freezingEffect.commands.utils;
 
+import dk.tij.freezingEffect.FreezingEffect;
 import dk.tij.freezingEffect.commands.CommandLabels;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public final class WinterTabCompleter implements TabCompleter {
+    private final FreezingEffect plugin;
+
+    public WinterTabCompleter(FreezingEffect plugin) {
+        this.plugin = plugin;
+    }
+
     @Override
     public List<String> onTabComplete(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] arguments) {
+        // /winter <reload/debug/config>
         if (arguments.length == 1) {
-            return List.of(CommandLabels.ARGUMENT_RELOAD, CommandLabels.ARGUMENT_DEBUG);
+            return List.of(
+                    CommandLabels.ARGUMENT_RELOAD,
+                    CommandLabels.ARGUMENT_DEBUG,
+                    CommandLabels.ARGUMENT_CONFIG
+            );
         }
 
-        if (arguments.length == 2 && arguments[0].equals(CommandLabels.ARGUMENT_DEBUG)) {
+        // /winter debug <on/off>
+        if (arguments.length == 2 && arguments[0].equalsIgnoreCase(CommandLabels.ARGUMENT_DEBUG)) {
             return List.of(CommandLabels.DEBUG_ARGUMENT_ON, CommandLabels.DEBUG_ARGUMENT_OFF);
         }
 
+        // /winter config <get/set>
+        if (arguments.length == 2 && arguments[0].equalsIgnoreCase(CommandLabels.ARGUMENT_CONFIG)) {
+            return List.of(CommandLabels.CONFIG_ARGUMENT_GET, CommandLabels.CONFIG_ARGUMENT_SET);
+        }
+
+        // /winter config get <path...>
+        if (arguments.length == 3
+                && arguments[0].equalsIgnoreCase(CommandLabels.ARGUMENT_CONFIG)
+                && arguments[1].equalsIgnoreCase(CommandLabels.CONFIG_ARGUMENT_GET)) {
+
+            return getMatchingConfigPaths(arguments[2]);
+        }
+
+        // /winter config set <path> <value>
+        if (arguments.length == 3
+                && arguments[0].equalsIgnoreCase(CommandLabels.ARGUMENT_CONFIG)
+                && arguments[1].equalsIgnoreCase(CommandLabels.CONFIG_ARGUMENT_SET)) {
+
+            return getMatchingConfigPaths(arguments[2]);
+        }
+
+        // /winter config set <path> <value>
+        // Suggest nothing, user types free-form value
         return Collections.emptyList();
+    }
+
+    private List<String> getMatchingConfigPaths(String typed) {
+        Set<String> keys = plugin.getConfig().getKeys(true);
+        List<String> suggestions = new ArrayList<>();
+
+        for (String key : keys) {
+            if (key.startsWith(typed)) {
+                suggestions.add(key);
+            }
+        }
+
+        return suggestions;
     }
 }

--- a/src/main/java/dk/tij/freezingEffect/handler/ResourceHandler.java
+++ b/src/main/java/dk/tij/freezingEffect/handler/ResourceHandler.java
@@ -8,17 +8,15 @@ import dk.tij.freezingEffect.utils.Maths;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import static dk.tij.freezingEffect.utils.Maths.TO_PERCENT_CONVERSION_FACTOR;
 
 public class ResourceHandler {
     private final FreezingEffect plugin;
-    private final FileConfiguration config;
+    private FileConfiguration config;
 
     public ResourceHandler(FreezingEffect plugin) {
         this.plugin = plugin;
-        this.config = plugin.getConfig();
         loadConfig();
     }
 
@@ -27,6 +25,7 @@ public class ResourceHandler {
     }
 
     public void loadConfig() {
+        this.config = plugin.getConfig();
         loadFrostPlayerStats();
         loadIsolationValues();
         loadHeatSourceValues();

--- a/src/main/java/dk/tij/freezingEffect/handler/ResourceHandler.java
+++ b/src/main/java/dk/tij/freezingEffect/handler/ResourceHandler.java
@@ -1,5 +1,6 @@
 package dk.tij.freezingEffect.handler;
 
+import dk.tij.freezingEffect.FreezingEffect;
 import dk.tij.freezingEffect.utils.HeatSource;
 import dk.tij.freezingEffect.constants.TemperatureConstants;
 import dk.tij.freezingEffect.utils.ItemUtils;
@@ -9,14 +10,20 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
-public class ResourceHandler {
-    private static final double TO_PERCENT_CONVERSION_FACTOR = 1d / 100d;
+import static dk.tij.freezingEffect.utils.Maths.TO_PERCENT_CONVERSION_FACTOR;
 
+public class ResourceHandler {
+    private final FreezingEffect plugin;
     private final FileConfiguration config;
 
-    public ResourceHandler(JavaPlugin plugin) {
+    public ResourceHandler(FreezingEffect plugin) {
+        this.plugin = plugin;
         this.config = plugin.getConfig();
         loadConfig();
+    }
+
+    public void saveConfig() {
+        plugin.saveConfig();
     }
 
     public void loadConfig() {
@@ -24,6 +31,19 @@ public class ResourceHandler {
         loadIsolationValues();
         loadHeatSourceValues();
         loadInterpolationFunction();
+    }
+
+    public void reloadConfig() {
+        loadConfig();
+    }
+
+    public void setDebug(boolean debug) {
+        config.set("frost.debug", debug);
+        saveConfig();
+    }
+
+    public boolean isDebug() {
+        return config.getBoolean("frost.debug");
     }
 
     private void loadFrostPlayerStats() {

--- a/src/main/java/dk/tij/freezingEffect/handler/TemperatureHandler.java
+++ b/src/main/java/dk/tij/freezingEffect/handler/TemperatureHandler.java
@@ -1,5 +1,7 @@
 package dk.tij.freezingEffect.handler;
 
+import dk.tij.freezingEffect.FreezingEffect;
+import dk.tij.freezingEffect.commands.utils.AdminDebug;
 import dk.tij.freezingEffect.utils.*;
 import dk.tij.freezingEffect.constants.TemperatureConstants;
 import org.bukkit.Bukkit;
@@ -15,7 +17,7 @@ import java.util.Map;
 import java.util.UUID;
 
 public class TemperatureHandler {
-    private final JavaPlugin plugin;
+    private final FreezingEffect plugin;
     private final FreezeHandler freezeHandler;
 
     private final Map<UUID, Double> actualPlayerFreezeTicks = new HashMap<>();
@@ -24,40 +26,33 @@ public class TemperatureHandler {
     private BukkitRunnable decayTask;
     private BukkitRunnable leatherArmourDamageTask;
 
-    public TemperatureHandler(JavaPlugin plugin, FreezeHandler freezeHandler) {
+    public TemperatureHandler(FreezingEffect plugin, FreezeHandler freezeHandler) {
         this.plugin = plugin;
         this.freezeHandler = freezeHandler;
         this.freezingDamageSource = DamageSource.builder(DamageType.FREEZE).build();
     }
 
     public void startDecayTask() {
-        if (decayTask == null) {
-            decayTask = new BukkitRunnable() {
-                @Override
-                public void run() {
-                    Bukkit.getOnlinePlayers().forEach(player -> tickPlayerTemperature(player));
-                    for (Player player : Bukkit.getOnlinePlayers()) {
-                        tickPlayerTemperature(player);
-                    }
-                }
-            };
-        }
-        if (leatherArmourDamageTask == null) {
-            leatherArmourDamageTask = new BukkitRunnable() {
-                @Override
-                public void run() {
-                    Bukkit.getOnlinePlayers().forEach(player -> applyDamageIfLeatherArmour(player));
-                }
-            };
-        }
+        decayTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                Bukkit.getOnlinePlayers().forEach(player -> tickPlayerTemperature(player));
+            }
+        };
         decayTask.runTaskTimer(plugin, 0L, 1L);
+        leatherArmourDamageTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                Bukkit.getOnlinePlayers().forEach(player -> applyDamageIfLeatherArmour(player));
+            }
+        };
         leatherArmourDamageTask.runTaskTimer(plugin, 1L, TemperatureConstants.VANILLA_DAMAGE_FREEZE_TICKS);
     }
 
     public void stopDecayTask() {
         if (decayTask == null) return;
-        if (leatherArmourDamageTask == null) return;
         decayTask.cancel();
+        if (leatherArmourDamageTask == null) return;
         leatherArmourDamageTask.cancel();
     }
 
@@ -105,8 +100,8 @@ public class TemperatureHandler {
 
         int freezeTicks = updatePlayerFreezingPoints(player, (int) nextActualFreezeTick);
 
-        player.sendMessage(String.format("FreezeTicks %3d | FractionalTarget: %3.1f | FreezePoints: %4.2f",
-                freezeTicks, fractionalChange, nextActualFreezeTick));
+        if (plugin.isDebug())
+            AdminDebug.printFreezeTicks(player, freezeTicks, fractionalChange, nextActualFreezeTick);
     }
 
     private void applyDamageIfLeatherArmour(Player player) {

--- a/src/main/java/dk/tij/freezingEffect/utils/Maths.java
+++ b/src/main/java/dk/tij/freezingEffect/utils/Maths.java
@@ -1,6 +1,8 @@
 package dk.tij.freezingEffect.utils;
 
 public final class Maths {
+    public static final double TO_PERCENT_CONVERSION_FACTOR = 1d / 100d;
+
     public static int clampI(int value, int min, int max) {
         return Math.max(min, Math.min(max, value));
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,6 +2,7 @@ frost:
   criticalFreezingTicks: 1800
   heatRadius: 5.0
   interpolationFunction: 'smootherstep'
+  debug: true
 
   isolation:
     maxPossibleIsolation: 80

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: FreezingEffect
-version: '0.5.0_dev'
+version: '0.5.1_dev'
 main: dk.tij.freezingEffect.FreezingEffect
 api-version: '1.21'
 permissions:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,3 +2,13 @@ name: FreezingEffect
 version: '0.5.0_dev'
 main: dk.tij.freezingEffect.FreezingEffect
 api-version: '1.21'
+permissions:
+  freezingeffect.command:
+    description: Allows running /winter commands
+    default: op
+commands:
+  winter:
+    description: Main command for FreezingEffect
+    usage: /winter <reload|debug>
+    aliases: [w, fe]
+    permission: freezingeffect.command


### PR DESCRIPTION
Added debug functionality, that can now be turned on or off.
Admins can modify the config and reload it via a command instead of restarting the server.
Admins can modify the config from within the game or read config values.
However, when setting config entries through the games commands, admins have to ensure that they are settings the right type. Otherwise, when reloading the config (happens automatically after setting), it may fall back to hardcoded values, that may or may not seem useful.

resolves #17 